### PR TITLE
fix: harden popup request flow and clipboard guards

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -12,6 +12,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::Mutex;
 
 static CLIPBOARD_MONITOR_RUNNING: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+const MAX_CLIPBOARD_HISTORY_BYTES: usize = 50_000;
 
 /// Payload sent when clipboard content changes
 #[derive(Clone, serde::Serialize)]
@@ -190,6 +191,15 @@ impl ClipboardMonitor {
     /// Handle a clipboard change event
     async fn handle_clipboard_change(app_handle: &AppHandle, text: String) -> Result<(), String> {
         log::info!("Clipboard changed: {} chars", text.len());
+
+        if text.len() > MAX_CLIPBOARD_HISTORY_BYTES {
+            log::warn!(
+                "Skipping clipboard history save for oversized payload ({} bytes > {} bytes)",
+                text.len(),
+                MAX_CLIPBOARD_HISTORY_BYTES
+            );
+            return Ok(());
+        }
 
         // Get app state
         let state = app_handle

--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -70,8 +70,8 @@ pub async fn get_clipboard_history(
     search_query: Option<String>,
 ) -> Result<ClipboardHistoryResponse, String> {
     let db = &state.db;
-    let limit = limit.unwrap_or(50).min(200);
-    let offset = offset.unwrap_or(0);
+    let limit = limit.unwrap_or(50).clamp(1, 200);
+    let offset = offset.unwrap_or(0).max(0);
 
     let (items, total) = db
         .get_clipboard_history(limit, offset, search_query.as_deref())

--- a/src/components/PolishPopup/PolishPopup.tsx
+++ b/src/components/PolishPopup/PolishPopup.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/store";
 import type { PolishContext, PolishChannel, PolishOption, ClaudeModel } from "@/types";
 import { CLAUDE_MODELS } from "@/types";
+import { hideAndPasteText } from "@/utils/hideAndPasteText";
 
 interface PolishPopupProps {
   sourceText: string;
@@ -94,18 +95,14 @@ export function PolishPopup({
     const textToReplace = fullText || streamedText;
     if (textToReplace) {
       try {
-        // Run hide + paste in one backend command to avoid a race where the
-        // second invoke is dropped after hiding the WebView.
-        const response = await invoke<{
-          success: boolean;
-          error?: { code: string; message: string };
-        }>("hide_and_paste_text", { text: textToReplace });
+        const response = await hideAndPasteText(textToReplace);
         if (!response.success && response.error) {
           console.error(
             "Paste failed:",
             response.error.code,
             response.error.message
           );
+          return;
         }
         onClose();
       } catch (err) {

--- a/src/components/TranslationPopup/TranslationPopup.tsx
+++ b/src/components/TranslationPopup/TranslationPopup.tsx
@@ -4,6 +4,7 @@ import { useTranslationStream } from "@/hooks/useTranslationStream";
 import { useWindowDrag } from "@/hooks/useWindowDrag";
 import { useClipboardStore } from "@/store";
 import { CLAUDE_MODELS, type ClaudeModel } from "@/types";
+import { hideAndPasteText } from "@/utils/hideAndPasteText";
 
 interface TranslationPopupProps {
   sourceText: string;
@@ -77,14 +78,10 @@ export function TranslationPopup({
     const textToReplace = fullText || streamedText;
     if (textToReplace) {
       try {
-        // Run hide + paste in one backend command to avoid a race where the
-        // second invoke is dropped after hiding the WebView.
-        const response = await invoke<{ success: boolean; error?: { code: string; message: string } }>(
-          "hide_and_paste_text",
-          { text: textToReplace }
-        );
+        const response = await hideAndPasteText(textToReplace);
         if (!response.success && response.error) {
           console.error("Paste failed:", response.error.code, response.error.message);
+          return;
         }
         onClose();
       } catch (err) {

--- a/src/hooks/usePolishStream.test.tsx
+++ b/src/hooks/usePolishStream.test.tsx
@@ -239,4 +239,76 @@ describe("usePolishStream", () => {
     expect(result.current.streamedText).toBe("");
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it("supersedes an in-flight polish request with the latest one", async () => {
+    let firstChannel:
+      | {
+          onmessage?: (event: {
+            event: string;
+            data: Record<string, unknown>;
+          }) => void;
+        }
+      | null = null;
+    let resolveFirstStream: (() => void) | undefined;
+
+    invokeWithTimeoutMock.mockImplementation((cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "polish_stream" && args.text === "first draft") {
+        firstChannel = args.onEvent as {
+          onmessage?: (event: {
+            event: string;
+            data: Record<string, unknown>;
+          }) => void;
+        };
+        return new Promise<void>((resolve) => {
+          resolveFirstStream = resolve;
+        });
+      }
+
+      if (cmd === "polish_stream" && args.text === "second draft") {
+        const channel = args.onEvent as {
+          onmessage?: (event: {
+            event: string;
+            data: Record<string, unknown>;
+          }) => void;
+        };
+        channel.onmessage?.({
+          event: "started",
+          data: { detectedLanguage: "en" },
+        });
+        channel.onmessage?.({
+          event: "completed",
+          data: {
+            fullText: "latest polish",
+            tokenUsage: null,
+          },
+        });
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.resolve(undefined);
+    });
+
+    const { result } = renderHook(() => usePolishStream());
+
+    let firstPromise: Promise<void> | undefined;
+    await act(async () => {
+      firstPromise = result.current.polish("first draft", "peer-discussion", "slack-message", []);
+      await Promise.resolve();
+      await result.current.polish("second draft", "peer-discussion", "slack-message", []);
+    });
+
+    expect(result.current.fullText).toBe("latest polish");
+    expect(result.current.streamedText).toBe("latest polish");
+    expect(result.current.detectedLanguage).toBe("en");
+
+    act(() => {
+      firstChannel?.onmessage?.({ event: "delta", data: { text: "stale" } });
+    });
+
+    expect(result.current.fullText).toBe("latest polish");
+    expect(result.current.streamedText).toBe("latest polish");
+
+    resolveFirstStream?.();
+    await firstPromise;
+  });
 });

--- a/src/hooks/usePolishStream.ts
+++ b/src/hooks/usePolishStream.ts
@@ -61,6 +61,16 @@ export function usePolishStream(): UsePolishStreamReturn {
     detachActiveChannel();
   }, [detachActiveChannel]);
 
+  const resetPolishState = useCallback(() => {
+    accumulatedTextRef.current = "";
+    setIsStreaming(false);
+    setStreamedText("");
+    setFullText("");
+    setError(null);
+    setTokenUsage(null);
+    setDetectedLanguage(null);
+  }, []);
+
   const applyPolishResponse = useCallback((response: PolishResponse) => {
     setDetectedLanguage(response.detectedLanguage ?? null);
     setTokenUsage(response.tokenUsage ?? null);
@@ -98,22 +108,16 @@ export function usePolishStream(): UsePolishStreamReturn {
       options: PolishOption[],
       model?: string
     ): Promise<void> => {
-      // Prevent concurrent calls
-      if (isPolishingRef.current) {
-        return;
-      }
+      // The latest request should win; otherwise the popup can show a new
+      // source text alongside an older polish result.
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
       isPolishingRef.current = true;
-      const requestId = ++requestIdRef.current;
       const isStaleRequest = () => !isMountedRef.current || requestId !== requestIdRef.current;
       detachActiveChannel();
+      resetPolishState();
 
       setIsStreaming(true);
-      setStreamedText("");
-      setFullText("");
-      setError(null);
-      setTokenUsage(null);
-      setDetectedLanguage(null);
-      accumulatedTextRef.current = "";
 
       try {
         const channel = new Channel<PolishStreamEvent>();
@@ -221,18 +225,13 @@ export function usePolishStream(): UsePolishStreamReturn {
         }
       }
     },
-    [applyPolishResponse, detachActiveChannel]
+    [applyPolishResponse, detachActiveChannel, resetPolishState]
   );
 
   const clearResult = useCallback(() => {
     invalidateActiveRequest();
-    setIsStreaming(false);
-    setStreamedText("");
-    setFullText("");
-    setError(null);
-    setTokenUsage(null);
-    setDetectedLanguage(null);
-  }, [invalidateActiveRequest]);
+    resetPolishState();
+  }, [invalidateActiveRequest, resetPolishState]);
 
   return {
     polish,

--- a/src/hooks/useTranslationStream.test.tsx
+++ b/src/hooks/useTranslationStream.test.tsx
@@ -230,13 +230,40 @@ describe("useTranslationStream", () => {
     expect(result.current.isStreaming).toBe(false);
   });
 
-  it("ignores concurrent translate calls", async () => {
+  it("supersedes an in-flight translate call with the latest request", async () => {
+    let firstChannel:
+      | {
+          onmessage?: (event: {
+            event: string;
+            data: Record<string, unknown>;
+          }) => void;
+        }
+      | null = null;
     let resolveStream: (() => void) | undefined;
-    invokeWithTimeoutMock.mockImplementation((cmd: string) => {
+    invokeWithTimeoutMock.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
       if (cmd === "get_cached_translation") {
-        return Promise.resolve(null);
+        if (args?.text === "first") {
+          return Promise.resolve(null);
+        }
+
+        if (args?.text === "second") {
+          return Promise.resolve({
+            success: true,
+            translatedText: "두번째 결과",
+            detectedLanguage: "en",
+            fromCache: true,
+            glossaryApplied: [],
+            tokenUsage: null,
+          });
+        }
       }
-      if (cmd === "translate_stream") {
+      if (cmd === "translate_stream" && args?.text === "first") {
+        firstChannel = args.onEvent as {
+          onmessage?: (event: {
+            event: string;
+            data: Record<string, unknown>;
+          }) => void;
+        };
         return new Promise<void>((resolve) => {
           resolveStream = resolve;
         });
@@ -253,7 +280,16 @@ describe("useTranslationStream", () => {
       await result.current.translate("second");
     });
 
-    expect(invokeWithTimeoutMock).toHaveBeenCalledTimes(2);
+    expect(result.current.fullText).toBe("두번째 결과");
+    expect(result.current.streamedText).toBe("두번째 결과");
+    expect(result.current.fromCache).toBe(true);
+
+    act(() => {
+      firstChannel?.onmessage?.({ event: "delta", data: { text: "stale" } });
+    });
+
+    expect(result.current.fullText).toBe("두번째 결과");
+    expect(result.current.streamedText).toBe("두번째 결과");
 
     resolveStream?.();
     await firstPromise;

--- a/src/hooks/useTranslationStream.ts
+++ b/src/hooks/useTranslationStream.ts
@@ -60,6 +60,18 @@ export function useTranslationStream(
     detachActiveChannel();
   }, [detachActiveChannel]);
 
+  const resetTranslateState = useCallback(() => {
+    accumulatedTextRef.current = "";
+    setIsStreaming(false);
+    setStreamedText("");
+    setFullText("");
+    setError(null);
+    setFromCache(false);
+    setGlossaryApplied([]);
+    setTokenUsage(null);
+    setDetectedLanguage(null);
+  }, []);
+
   const applyTranslateResponse = useCallback((response: TranslateResponse) => {
     setDetectedLanguage(response.detectedLanguage ?? null);
     setFromCache(response.fromCache);
@@ -93,17 +105,15 @@ export function useTranslationStream(
 
   const translate = useCallback(
     async (text: string, model?: string): Promise<void> => {
-      // Prevent concurrent calls
-      if (isTranslatingRef.current) {
-        return;
-      }
+      // The latest request should win; otherwise the popup can show a new
+      // source text alongside an older translation result.
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
       isTranslatingRef.current = true;
-      const requestId = ++requestIdRef.current;
       const isStaleRequest = () => !isMountedRef.current || requestId !== requestIdRef.current;
       detachActiveChannel();
+      resetTranslateState();
       const sourceLanguage = normalizeSourceLanguage(options.sourceLanguage);
-
-      setError(null);
 
       try {
         // Fast path: if cached, bypass streaming channel entirely.
@@ -126,13 +136,6 @@ export function useTranslationStream(
 
         // Streaming path (cache miss)
         setIsStreaming(true);
-        setStreamedText("");
-        setFullText("");
-        setFromCache(false);
-        setGlossaryApplied([]);
-        setTokenUsage(null);
-        setDetectedLanguage(null);
-        accumulatedTextRef.current = "";
 
         const channel = new Channel<TranslateStreamEvent>();
         activeChannelRef.current = channel;
@@ -239,20 +242,19 @@ export function useTranslationStream(
         }
       }
     },
-    [applyTranslateResponse, detachActiveChannel, options.sourceLanguage, options.targetLanguage]
+    [
+      applyTranslateResponse,
+      detachActiveChannel,
+      options.sourceLanguage,
+      options.targetLanguage,
+      resetTranslateState,
+    ]
   );
 
   const clearResult = useCallback(() => {
     invalidateActiveRequest();
-    setIsStreaming(false);
-    setStreamedText("");
-    setFullText("");
-    setError(null);
-    setFromCache(false);
-    setGlossaryApplied([]);
-    setTokenUsage(null);
-    setDetectedLanguage(null);
-  }, [invalidateActiveRequest]);
+    resetTranslateState();
+  }, [invalidateActiveRequest, resetTranslateState]);
 
   return {
     translate,

--- a/src/utils/hideAndPasteText.test.ts
+++ b/src/utils/hideAndPasteText.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { hideAndPasteText } from "./hideAndPasteText";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const showMock = vi.fn();
+const setFocusMock = vi.fn();
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(),
+}));
+
+const invokeMock = vi.mocked(invoke);
+const getCurrentWindowMock = vi.mocked(getCurrentWindow);
+
+describe("hideAndPasteText", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    showMock.mockReset();
+    setFocusMock.mockReset();
+    showMock.mockResolvedValue(undefined);
+    setFocusMock.mockResolvedValue(undefined);
+    getCurrentWindowMock.mockReturnValue({
+      show: showMock,
+      setFocus: setFocusMock,
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+  });
+
+  it("returns successful paste results without restoring the window", async () => {
+    invokeMock.mockResolvedValue({ success: true });
+
+    await expect(hideAndPasteText("translated")).resolves.toEqual({ success: true });
+    expect(showMock).not.toHaveBeenCalled();
+    expect(setFocusMock).not.toHaveBeenCalled();
+  });
+
+  it("restores the popup window when the backend paste reports failure", async () => {
+    invokeMock.mockResolvedValue({
+      success: false,
+      error: { code: "PASTE_FAILED", message: "boom" },
+    });
+
+    await expect(hideAndPasteText("translated")).resolves.toEqual({
+      success: false,
+      error: { code: "PASTE_FAILED", message: "boom" },
+    });
+
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(setFocusMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the popup window before rethrowing invoke failures", async () => {
+    invokeMock.mockRejectedValue(new Error("invoke failed"));
+
+    await expect(hideAndPasteText("translated")).rejects.toThrow("invoke failed");
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(setFocusMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/hideAndPasteText.ts
+++ b/src/utils/hideAndPasteText.ts
@@ -1,0 +1,41 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export interface HideAndPasteResponse {
+  success: boolean;
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+async function restorePopupWindow() {
+  const window = getCurrentWindow();
+
+  try {
+    await window.show();
+  } catch (err) {
+    console.error("Failed to restore hidden popup window:", err);
+  }
+
+  try {
+    await window.setFocus();
+  } catch (err) {
+    console.error("Failed to focus restored popup window:", err);
+  }
+}
+
+export async function hideAndPasteText(text: string): Promise<HideAndPasteResponse> {
+  try {
+    const response = await invoke<HideAndPasteResponse>("hide_and_paste_text", { text });
+
+    if (!response.success) {
+      await restorePopupWindow();
+    }
+
+    return response;
+  } catch (err) {
+    await restorePopupWindow();
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- harden popup request flow to avoid overlapping or stale request handling
- add clipboard guards around paste/copy paths to reduce unsafe or invalid operations
- tighten related state handling for more reliable popup behavior

## Validation
- pnpm lint
- pnpm test
- pnpm build
