### PR TITLE
fix: preserve history origin across polish translate flow

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -61,9 +61,18 @@ vi.mock("@/components/TranslationPopup", () => ({
 }));
 
 vi.mock("@/components/PolishPopup", () => ({
-  PolishPopup: ({ sourceText, onClose }: { sourceText: string; onClose: () => void }) => (
+  PolishPopup: ({
+    sourceText,
+    onClose,
+    onTranslate,
+  }: {
+    sourceText: string;
+    onClose: () => void;
+    onTranslate?: (text: string) => void;
+  }) => (
     <div data-testid="polish-popup">
       <span>{sourceText}</span>
+      <button data-testid="polish-translate" onClick={() => onTranslate?.("polished-text")}>translate</button>
       <button data-testid="polish-close" onClick={onClose}>close</button>
     </div>
   ),
@@ -139,6 +148,35 @@ describe("App", () => {
 
     fireEvent.click(screen.getByTestId("drawer-translate"));
     expect(await screen.findByTestId("translation-popup")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("translation-close"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("drawer-panel")).toBeInTheDocument();
+    });
+    expect(hideMock).not.toHaveBeenCalled();
+  });
+
+  it("returns to history after translating from a polish popup opened from history", async () => {
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+
+    act(() => {
+      emit("show_history", {});
+    });
+    expect(await screen.findByTestId("drawer-panel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("drawer-polish"));
+    expect(await screen.findByTestId("polish-popup")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("polish-translate"));
+    expect(await screen.findByTestId("translation-popup")).toBeInTheDocument();
+    expect(screen.getByText("polished-text")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("translation-close"));
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -366,7 +366,6 @@ function App() {
   // Handle translate from polish popup
   const handleTranslateFromPolish = useCallback((text: string) => {
     setSourceText(text);
-    setOpenedFromHistory(false);
     setPopupMode("translate");
   }, []);
 


### PR DESCRIPTION
## Summary
- keep the history-origin state when moving from a history-opened polish popup into translation
- add a regression test for history -> polish -> translate -> close

## Verification
- pnpm test
- pnpm build