### PR TITLE
Preserve clipboard history search on refresh

### DIFF
--- a/src/components/ClipboardHistory/HistoryPanel.test.tsx
+++ b/src/components/ClipboardHistory/HistoryPanel.test.tsx
@@ -1,0 +1,57 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HistoryPanel } from "./HistoryPanel";
+
+const fetchHistoryMock = vi.fn();
+const listeners = new Map<string, () => void>();
+
+vi.mock("@/store", () => ({
+  useClipboardStore: () => ({
+    items: [],
+    isLoading: false,
+    error: null,
+    hasMore: false,
+    fetchHistory: fetchHistoryMock,
+    deleteItem: vi.fn(),
+    togglePin: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((eventName: string, callback: () => void) => {
+    listeners.set(eventName, callback);
+    return Promise.resolve(() => {
+      listeners.delete(eventName);
+    });
+  }),
+}));
+
+describe("HistoryPanel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchHistoryMock.mockReset();
+    listeners.clear();
+  });
+
+  it("preserves the active search query when clipboard refresh events arrive", async () => {
+    render(<HistoryPanel />);
+
+    const searchInput = screen.getByPlaceholderText("Search clipboard history...");
+    fireEvent.change(searchInput, { target: { value: "urgent" } });
+
+    expect(fetchHistoryMock).toHaveBeenNthCalledWith(1);
+    expect(fetchHistoryMock).toHaveBeenNthCalledWith(2, { searchQuery: "urgent" });
+
+    act(() => {
+      listeners.get("clipboard_changed")?.();
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(fetchHistoryMock).toHaveBeenNthCalledWith(3, { searchQuery: "urgent" });
+  });
+});

--- a/src/components/ClipboardHistory/HistoryPanel.tsx
+++ b/src/components/ClipboardHistory/HistoryPanel.tsx
@@ -10,8 +10,13 @@ export function HistoryPanel() {
   const [searchQuery, setSearchQuery] = useState("");
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const searchQueryRef = useRef("");
   const { items, isLoading, error, hasMore, fetchHistory, deleteItem, togglePin, clearAll } =
     useClipboardStore();
+
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  }, [searchQuery]);
 
   useEffect(() => {
     fetchHistory();
@@ -22,7 +27,9 @@ export function HistoryPanel() {
   useEffect(() => {
     const unlisten = listen<ClipboardChangedPayload>("clipboard_changed", () => {
       clearTimeout(clipboardDebounceRef.current);
-      clipboardDebounceRef.current = setTimeout(() => fetchHistory(), 100);
+      clipboardDebounceRef.current = setTimeout(() => {
+        fetchHistory({ searchQuery: searchQueryRef.current || undefined });
+      }, 100);
     });
 
     return () => {
@@ -34,6 +41,7 @@ export function HistoryPanel() {
   const handleSearch = useCallback(
     (query: string) => {
       setSearchQuery(query);
+      searchQueryRef.current = query;
       fetchHistory({ searchQuery: query || undefined });
     },
     [fetchHistory]

--- a/src/components/DrawerPanel/DrawerPanel.tsx
+++ b/src/components/DrawerPanel/DrawerPanel.tsx
@@ -103,6 +103,11 @@ export function DrawerPanel({
   const lastSavedWidthRef = useRef<number>(0);
   const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingTimeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  const searchQueryRef = useRef("");
+
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  }, [searchQuery]);
 
   const scheduleTimeout = useCallback((callback: () => void | Promise<void>, delayMs: number) => {
     const timeoutId = setTimeout(() => {
@@ -169,7 +174,7 @@ export function DrawerPanel({
   useEffect(() => {
     const unlisten = listen<{ mode: string; itemId?: string }>("postit_saved", async (event) => {
       // Refresh history when a postit is saved
-      await fetchHistory();
+      await fetchHistory({ searchQuery: searchQueryRef.current || undefined });
       const message = event.payload.mode === "edit" ? "수정되었습니다" : "메모가 생성되었습니다";
       setToast({ message, type: "success" });
     });
@@ -223,7 +228,9 @@ export function DrawerPanel({
   useEffect(() => {
     const unlisten = listen<ClipboardChangedPayload>("clipboard_changed", () => {
       clearTimeout(clipboardDebounceRef.current);
-      clipboardDebounceRef.current = setTimeout(() => fetchHistory(), 100);
+      clipboardDebounceRef.current = setTimeout(() => {
+        fetchHistory({ searchQuery: searchQueryRef.current || undefined });
+      }, 100);
     });
     return () => {
       clearTimeout(clipboardDebounceRef.current);
@@ -398,6 +405,7 @@ export function DrawerPanel({
   const handleSearch = useCallback(
     (query: string) => {
       setSearchQuery(query);
+      searchQueryRef.current = query;
       fetchHistory({ searchQuery: query || undefined });
     },
     [fetchHistory]


### PR DESCRIPTION
## Summary
- preserve the active search query when clipboard history refreshes from clipboard events
- preserve the same search query after post-it save refreshes in the drawer view
- add a regression test covering the history panel refresh behavior

## Testing
- pnpm vitest run src/components/ClipboardHistory/HistoryPanel.test.tsx
- pnpm test