### PR TITLE
Fix history refresh while search is active

### DIFF
--- a/src/components/ClipboardHistory/HistoryPanel.test.tsx
+++ b/src/components/ClipboardHistory/HistoryPanel.test.tsx
@@ -1,0 +1,93 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HistoryPanel } from "./HistoryPanel";
+import { useClipboardStore } from "@/store";
+
+type TauriListenEvent = {
+  payload: Record<string, unknown>;
+};
+
+type ListenerCallback = (event: TauriListenEvent) => void;
+
+const listeners = new Map<string, ListenerCallback>();
+const invokeMock = vi.fn();
+const listenMock = vi.fn((eventName: string, callback: ListenerCallback) => {
+  listeners.set(eventName, callback);
+  return Promise.resolve(() => {
+    listeners.delete(eventName);
+  });
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+function emit(eventName: string, payload: Record<string, unknown> = {}) {
+  const callback = listeners.get(eventName);
+  if (!callback) {
+    throw new Error(`No listener registered for ${eventName}`);
+  }
+  callback({ payload });
+}
+
+describe("HistoryPanel", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    listeners.clear();
+    invokeMock.mockReset();
+    listenMock.mockClear();
+    useClipboardStore.setState({
+      items: [],
+      total: 0,
+      hasMore: false,
+      isLoading: false,
+      error: null,
+    });
+
+    invokeMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      hasMore: false,
+    });
+  });
+
+  it("preserves the active search query when clipboard changes trigger a refresh", async () => {
+    render(<HistoryPanel />);
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("get_clipboard_history", {
+        limit: 50,
+        offset: 0,
+        searchQuery: undefined,
+      });
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Search clipboard history..."), {
+      target: { value: "alpha" },
+    });
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenLastCalledWith("get_clipboard_history", {
+        limit: 50,
+        offset: 0,
+        searchQuery: "alpha",
+      });
+    });
+
+    act(() => {
+      emit("clipboard_changed");
+    });
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenLastCalledWith("get_clipboard_history", {
+        limit: 50,
+        offset: 0,
+        searchQuery: "alpha",
+      });
+    });
+  });
+});

--- a/src/components/ClipboardHistory/HistoryPanel.tsx
+++ b/src/components/ClipboardHistory/HistoryPanel.tsx
@@ -10,8 +10,13 @@ export function HistoryPanel() {
   const [searchQuery, setSearchQuery] = useState("");
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const latestSearchQueryRef = useRef("");
   const { items, isLoading, error, hasMore, fetchHistory, deleteItem, togglePin, clearAll } =
     useClipboardStore();
+
+  useEffect(() => {
+    latestSearchQueryRef.current = searchQuery;
+  }, [searchQuery]);
 
   useEffect(() => {
     fetchHistory();
@@ -22,7 +27,10 @@ export function HistoryPanel() {
   useEffect(() => {
     const unlisten = listen<ClipboardChangedPayload>("clipboard_changed", () => {
       clearTimeout(clipboardDebounceRef.current);
-      clipboardDebounceRef.current = setTimeout(() => fetchHistory(), 100);
+      clipboardDebounceRef.current = setTimeout(() => {
+        const activeQuery = latestSearchQueryRef.current || undefined;
+        fetchHistory({ searchQuery: activeQuery });
+      }, 100);
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- preserve the active clipboard history search query when background clipboard refreshes run
- keep the debounced clipboard_changed listener aligned with the current filter state
- add a regression test covering clipboard refreshes during an active search

## Testing
- pnpm vitest run src/components/ClipboardHistory/HistoryPanel.test.tsx src/store/clipboardStore.test.ts
- pnpm vitest run src/App.test.tsx